### PR TITLE
WIP: Removed unnessessary method

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.conf.PropertyType;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,7 +106,7 @@ public class ConfigOpts extends Help {
       if (propArgs.length == 2) {
         value = propArgs[1].trim();
       } else { // if property is boolean then its mere existence assumes true
-        value = Property.isValidBooleanPropertyKey(key) ? "true" : "";
+        value = (Property.getPropertyByKey(key).getType() == PropertyType.BOOLEAN) ? "true" : "";
       }
       if (key.isEmpty() || value.isEmpty()) {
         throw new IllegalArgumentException("Invalid command line -o option: " + prop);

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1407,16 +1407,6 @@ public enum Property {
   }
 
   /**
-   * Checks if the given property key is a valid property and is of type boolean.
-   *
-   * @param key property key
-   * @return true if key is valid and is of type boolean, false otherwise
-   */
-  public static boolean isValidBooleanPropertyKey(String key) {
-    return validProperties.contains(key) && getPropertyByKey(key).getType() == PropertyType.BOOLEAN;
-  }
-
-  /**
    * Checks if the given property key is for a valid table property. A valid table property key is
    * either equal to the key of some defined table property (which each start with
    * {@link #TABLE_PREFIX}) or has a prefix matching {@link #TABLE_CONSTRAINT_PREFIX},


### PR DESCRIPTION
Removed method for checking if a property was a valid boolean type.
The method was replaced with a simple type comparison.

Breaking out a single type check to an entire method demonstrates a design pattern that, if continued, would clutter up the Property class.