### PR TITLE
WIP: Elasticity remove old compaction code

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -53,12 +53,40 @@ public enum Property {
           + "A new external compaction service would be defined like the following:\n"
           + "`compaction.service.newService.planner="
           + "\"org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner\".`\n"
-          + "`compaction.service.newService.opts.queues=\""
+          + "`compaction.service.newService.opts.groups=\""
           + "[{\"name\": \"small\", \"maxSize\":\"32M\"},"
           + "{ \"name\":\"medium\", \"maxSize\":\"512M\"},{\"name\":\"large\"}]`\n"
           + "`compaction.service.newService.opts.maxOpen=50`.\n"
           + "Additional options can be defined using the `compaction.service.<service>.opts.<option>` property.",
       "3.1.0"),
+  COMPACTION_SERVICE_ROOT_PLANNER(COMPACTION_SERVICE_PREFIX + "root.planner",
+      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
+      "Compaction planner for root tablet service.", "4.0.0"),
+  COMPACTION_SERVICE_ROOT_MAX_OPEN(COMPACTION_SERVICE_PREFIX + "root.planner.opts.maxOpen", "30",
+      PropertyType.COUNT, "The maximum number of files a compaction will open.", "4.0.0"),
+  COMPACTION_SERVICE_ROOT_GROUPS(COMPACTION_SERVICE_PREFIX + "root.planner.opts.groups",
+      "[{'name':'accumulo_meta'}]".replaceAll("'", "\""), PropertyType.STRING,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "4.0.0"),
+  COMPACTION_SERVICE_META_PLANNER(COMPACTION_SERVICE_PREFIX + "meta.planner",
+      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
+      "Compaction planner for metadata table.", "4.0.0"),
+  COMPACTION_SERVICE_META_MAX_OPEN(COMPACTION_SERVICE_PREFIX + "meta.planner.opts.maxOpen", "30",
+      PropertyType.COUNT, "The maximum number of files a compaction will open.", "4.0.0"),
+  COMPACTION_SERVICE_META_GROUPS(COMPACTION_SERVICE_PREFIX + "meta.planner.opts.groups",
+      "[{'name':'accumulo_meta'}]".replaceAll("'", "\""), PropertyType.JSON,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "4.0.0"),
+  COMPACTION_SERVICE_DEFAULT_PLANNER(COMPACTION_SERVICE_PREFIX + "default.planner",
+      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
+      "Planner for default compaction service.", "4.0.0"),
+  COMPACTION_SERVICE_DEFAULT_MAX_OPEN(COMPACTION_SERVICE_PREFIX + "default.planner.opts.maxOpen",
+      "10", PropertyType.COUNT, "The maximum number of files a compaction will open.", "4.0.0"),
+  COMPACTION_SERVICE_DEFAULT_GROUPS(COMPACTION_SERVICE_PREFIX + "default.planner.opts.groups",
+      ("[{'name':'user_small','maxSize':'128M'}, {'name':'user_large'}]").replaceAll("'", "\""),
+      PropertyType.STRING,
+      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
+      "4.0.0"),
   COMPACTION_WARN_TIME(COMPACTION_PREFIX + "warn.time", "10m", PropertyType.TIMEDURATION,
       "When a compaction has not made progress for this time period, a warning will be logged.",
       "3.1.0"),
@@ -598,63 +626,8 @@ public enum Property {
       "2.1.0"),
   TSERV_MIGRATE_MAXCONCURRENT("tserver.migrations.concurrent.max", "1", PropertyType.COUNT,
       "The maximum number of concurrent tablet migrations for a tablet server.", "1.3.5"),
-  @Deprecated(since = "3.1")
-  @ReplacedBy(property = COMPACTION_SERVICE_PREFIX)
-  TSERV_COMPACTION_SERVICE_PREFIX("tserver.compaction.major.service.", null, PropertyType.PREFIX,
-      "Prefix for compaction services.", "2.1.0"),
-  @Deprecated(since = "3.1")
-  TSERV_COMPACTION_SERVICE_ROOT_PLANNER("tserver.compaction.major.service.root.planner",
-      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
-      "Compaction planner for root tablet service.", "2.1.0"),
-  @Deprecated(since = "3.1")
-  TSERV_COMPACTION_SERVICE_ROOT_MAX_OPEN(
-      "tserver.compaction.major.service.root.planner.opts.maxOpen", "30", PropertyType.COUNT,
-      "The maximum number of files a compaction will open.", "2.1.0"),
-  @Deprecated(since = "3.1")
-  TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS(
-      "tserver.compaction.major.service.root.planner.opts.executors",
-      "[{'name':'all','type':'external','group':'accumulo_meta'}]".replaceAll("'", "\""),
-      PropertyType.STRING,
-      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
-      "2.1.0"),
-  @Deprecated(since = "3.1")
-  TSERV_COMPACTION_SERVICE_META_PLANNER("tserver.compaction.major.service.meta.planner",
-      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
-      "Compaction planner for metadata table.", "2.1.0"),
-  @Deprecated(since = "3.1")
-  TSERV_COMPACTION_SERVICE_META_MAX_OPEN(
-      "tserver.compaction.major.service.meta.planner.opts.maxOpen", "30", PropertyType.COUNT,
-      "The maximum number of files a compaction will open.", "2.1.0"),
-  @Deprecated(since = "3.1")
-  TSERV_COMPACTION_SERVICE_META_EXECUTORS(
-      "tserver.compaction.major.service.meta.planner.opts.executors",
-      "[{'name':'all','type':'external','group':'accumulo_meta'}]".replaceAll("'", "\""),
-      PropertyType.JSON,
-      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
-      "2.1.0"),
-  @Deprecated(since = "3.1")
-  TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER("tserver.compaction.major.service.default.planner",
-      DefaultCompactionPlanner.class.getName(), PropertyType.CLASSNAME,
-      "Planner for default compaction service.", "2.1.0"),
-  @Deprecated(since = "3.1")
-  TSERV_COMPACTION_SERVICE_DEFAULT_MAX_OPEN(
-      "tserver.compaction.major.service.default.planner.opts.maxOpen", "10", PropertyType.COUNT,
-      "The maximum number of files a compaction will open.", "2.1.0"),
-  @Deprecated(since = "3.1")
-  TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS(
-      "tserver.compaction.major.service.default.planner.opts.executors",
-      ("[{'name':'small','type':'external','maxSize':'128M','group':'user_small'}, {'name':'large','type':'external','group':'user_large'}]")
-          .replaceAll("'", "\""),
-      PropertyType.STRING,
-      "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %}.",
-      "2.1.0"),
   TSERV_MINC_MAXCONCURRENT("tserver.compaction.minor.concurrent.max", "4", PropertyType.COUNT,
       "The maximum number of concurrent minor compactions for a tablet server.", "1.3.5"),
-  @Deprecated(since = "3.1")
-  @ReplacedBy(property = COMPACTION_WARN_TIME)
-  TSERV_COMPACTION_WARN_TIME("tserver.compaction.warn.time", "10m", PropertyType.TIMEDURATION,
-      "When a compaction has not made progress for this time period, a warning will be logged.",
-      "1.6.0"),
   TSERV_BLOOM_LOAD_MAXCONCURRENT("tserver.bloom.load.concurrent.max", "4", PropertyType.COUNT,
       "The number of concurrent threads that will load bloom filters in the background. "
           + "Setting this to zero will make bloom filters load in the foreground.",

--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -134,12 +134,12 @@ public class TabletLogger {
   public static void compacting(KeyExtent extent, CompactionJob job, CompactionConfig config) {
     if (fileLog.isDebugEnabled()) {
       if (config == null) {
-        fileLog.debug("Compacting {} on {} for {} from {} size {}", extent, job.getExecutor(),
+        fileLog.debug("Compacting {} on {} for {} from {} size {}", extent, job.getGroup(),
             job.getKind(), asMinimalString(job.getFiles()), getSize(job.getFiles()));
       } else {
         fileLog.debug("Compacting {} on {} for {} from {} size {} config {}", extent,
-            job.getExecutor(), job.getKind(), asMinimalString(job.getFiles()),
-            getSize(job.getFiles()), config);
+            job.getGroup(), job.getKind(), asMinimalString(job.getFiles()), getSize(job.getFiles()),
+            config);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -383,7 +383,7 @@ public interface Ample {
 
     T deleteSuspension();
 
-    T putExternalCompaction(ExternalCompactionId ecid, ExternalCompactionMetadata ecMeta);
+    T putExternalCompaction(ExternalCompactionId ecid, CompactionMetadata ecMeta);
 
     T deleteExternalCompaction(ExternalCompactionId ecid);
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -116,7 +116,7 @@ public class TabletMetadata {
   private OptionalLong flush = OptionalLong.empty();
   private List<LogEntry> logs;
   private Double splitRatio = null;
-  private Map<ExternalCompactionId,ExternalCompactionMetadata> extCompactions;
+  private Map<ExternalCompactionId,CompactionMetadata> extCompactions;
   private boolean merged;
   private TabletHostingGoal goal = TabletHostingGoal.ONDEMAND;
   private boolean onDemandHostingRequested = false;
@@ -414,7 +414,7 @@ public class TabletMetadata {
     return keyValues;
   }
 
-  public Map<ExternalCompactionId,ExternalCompactionMetadata> getExternalCompactions() {
+  public Map<ExternalCompactionId,CompactionMetadata> getExternalCompactions() {
     ensureFetched(ColumnType.ECOMP);
     return extCompactions;
   }
@@ -449,8 +449,7 @@ public class TabletMetadata {
     final var filesBuilder = ImmutableMap.<StoredTabletFile,DataFileValue>builder();
     final var scansBuilder = ImmutableList.<StoredTabletFile>builder();
     final var logsBuilder = ImmutableList.<LogEntry>builder();
-    final var extCompBuilder =
-        ImmutableMap.<ExternalCompactionId,ExternalCompactionMetadata>builder();
+    final var extCompBuilder = ImmutableMap.<ExternalCompactionId,CompactionMetadata>builder();
     final var loadedFilesBuilder = ImmutableMap.<StoredTabletFile,Long>builder();
     final var compactedBuilder = ImmutableSet.<Long>builder();
     ByteSequence row = null;
@@ -542,8 +541,7 @@ public class TabletMetadata {
           logsBuilder.add(LogEntry.fromMetaWalEntry(kv));
           break;
         case ExternalCompactionColumnFamily.STR_NAME:
-          extCompBuilder.put(ExternalCompactionId.of(qual),
-              ExternalCompactionMetadata.fromJson(val));
+          extCompBuilder.put(ExternalCompactionId.of(qual), CompactionMetadata.fromJson(val));
           break;
         case MergedColumnFamily.STR_NAME:
           te.merged = true;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadataBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadataBuilder.java
@@ -195,7 +195,7 @@ public class TabletMetadataBuilder implements Ample.TabletUpdates<TabletMetadata
 
   @Override
   public TabletMetadataBuilder putExternalCompaction(ExternalCompactionId ecid,
-      ExternalCompactionMetadata ecMeta) {
+      CompactionMetadata ecMeta) {
     fetched.add(ECOMP);
     internalBuilder.putExternalCompaction(ecid, ecMeta);
     return this;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMutatorBase.java
@@ -249,7 +249,7 @@ public abstract class TabletMutatorBase<T extends Ample.TabletUpdates<T>>
   }
 
   @Override
-  public T putExternalCompaction(ExternalCompactionId ecid, ExternalCompactionMetadata ecMeta) {
+  public T putExternalCompaction(ExternalCompactionId ecid, CompactionMetadata ecMeta) {
     mutation.put(ExternalCompactionColumnFamily.STR_NAME, ecid.canonical(), ecMeta.toJson());
     return getThis();
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionGroupId.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionGroupId.java
@@ -18,22 +18,20 @@
  */
 package org.apache.accumulo.core.spi.compaction;
 
+import org.apache.accumulo.core.data.AbstractId;
+
 /**
- * Offered to a Compaction Planner at initialization time so it can create executors.
+ * A unique identifier for a compaction group that a {@link CompactionPlanner} can schedule
+ * compactions on using a {@link CompactionJob}.
  *
- *
- * @since 2.1.0
- * @see CompactionPlanner#init(org.apache.accumulo.core.spi.compaction.CompactionPlanner.InitParameters)
+ * @since 3.1.0
  * @see org.apache.accumulo.core.spi.compaction
  */
-public interface ExecutorManager {
-  /**
-   * Create a thread pool executor within a compaction service.
-   */
-  public CompactionExecutorId createExecutor(String name, int threads);
+public class CompactionGroupId extends AbstractId<CompactionGroupId> {
+  // ELASTICITY_TODO make this cache ids like TableId. This will help save manager memory.
+  private static final long serialVersionUID = 1L;
 
-  /**
-   * @return an id for a configured external execution queue.
-   */
-  public CompactionExecutorId getExternalExecutor(String name);
+  protected CompactionGroupId(String canonical) {
+    super(canonical);
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionJob.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionJob.java
@@ -33,9 +33,9 @@ public interface CompactionJob {
   short getPriority();
 
   /**
-   * @return The executor to run the job.
+   * @return The group to run the job.
    */
-  CompactionExecutorId getExecutor();
+  CompactionGroupId getGroup();
 
   /**
    * @return The files to compact

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlan.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlan.java
@@ -42,12 +42,12 @@ public interface CompactionPlan {
      * @param priority This determines the order in which the job is taken off the execution queue.
      *        Larger numbers are taken off the queue first. If two jobs are on the queue, one with a
      *        priority of 4 and another with 5, then the one with 5 will be taken first.
-     * @param executor Where the job should run.
-     * @param group The files to compact.
+     * @param group Where the job should run.
+     * @param files The files to compact.
      * @return this
      */
-    Builder addJob(short priority, CompactionExecutorId executor,
-        Collection<CompactableFile> group);
+    Builder addJob(short priority, CompactionGroupId group,
+        Collection<CompactableFile> files);
 
     CompactionPlan build();
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlan.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlan.java
@@ -46,8 +46,7 @@ public interface CompactionPlan {
      * @param files The files to compact.
      * @return this
      */
-    Builder addJob(short priority, CompactionGroupId group,
-        Collection<CompactableFile> files);
+    Builder addJob(short priority, CompactionGroupId group, Collection<CompactableFile> files);
 
     CompactionPlan build();
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -61,10 +61,10 @@ public interface CompactionPlanner {
     String getFullyQualifiedOption(String key);
 
     /**
-     * @return an execution manager that can be used to created thread pools within a compaction
+     * @return a group manager that can be used to create groups for a compaction
      *         service.
      */
-    ExecutorManager getExecutorManager();
+    GroupManager getGroupManager();
   }
 
   public void init(InitParameters params);

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -61,8 +61,7 @@ public interface CompactionPlanner {
     String getFullyQualifiedOption(String key);
 
     /**
-     * @return a group manager that can be used to create groups for a compaction
-     *         service.
+     * @return a group manager that can be used to create groups for a compaction service.
      */
     GroupManager getGroupManager();
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -57,7 +57,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * compaction service you are configuring.
  *
  * <ul>
- * Note that the CompactionCoordinator and at least one Compactor for "Large" must be running.
+ * <li>Note that the CompactionCoordinator and at least one Compactor for "Large" must be running.
  * <li>{@code compaction.service.<service>.opts.maxOpen} This determines the maximum number of files
  * that will be included in a single compaction.
  * <li>{@code compaction.service.<service>.opts.groups} This is a json array of group objects which
@@ -78,18 +78,17 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * </tr>
  * </table>
  * <br>
- * This 'groups' object is used for defining compaction groups.
- *
- * The maxSize field determines the maximum size of compaction that will run in a
- * group. The maxSize field can have a suffix of K,M,G for kilobytes, megabytes, or gigabytes and
- * represents the sum of the input files for a given compaction. One group can have no max size
- * and it will run everything that is too large for the other groups. If all groups have a max
- * size, then system compactions will only run for compactions smaller than the largest max size.
- * User, chop, and selector compactions will always run, even if there is no group for their
- * size. These compactions will run on the group with the largest max size. The following example
- * value for this property will create three separate compaction groups. "small" will run compactions of files whose file size sum is
- * less than 100M, "medium" will run compactions of files whose file size sum is less than 500M, and "large" will run
- * all other compactions on Compactors configured to run compactions for Large:
+ * This 'groups' object is used for defining compaction groups. The maxSize field determines the
+ * maximum size of compaction that will run in a group. The maxSize field can have a suffix of K,M,G
+ * for kilobytes, megabytes, or gigabytes and represents the sum of the input files for a given
+ * compaction. One group can have no max size and it will run everything that is too large for the
+ * other groups. If all groups have a max size, then system compactions will only run for
+ * compactions smaller than the largest max size. User, chop, and selector compactions will always
+ * run, even if there is no group for their size. These compactions will run on the group with the
+ * largest max size. The following example value for this property will create three separate
+ * compaction groups. "small" will run compactions of files whose file size sum is less than 100M,
+ * "medium" will run compactions of files whose file size sum is less than 500M, and "large" will
+ * run all other compactions on Compactors configured to run compactions for Large:
  *
  * <pre>
  * {@code
@@ -99,7 +98,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *  {"name": "large"}
  * ]}
  * </pre>
- *
  * </ul>
  *
  * @since 3.1.0
@@ -245,7 +243,8 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     long maxSizeToCompact = getMaxSizeToCompact(params.getKind());
 
     // This set represents future files that will be produced by running compactions. If the optimal
-    // set of files to compact is computed and contains one of these files, then it's optimal to wait
+    // set of files to compact is computed and contains one of these files, then it's optimal to
+    // wait
     // for this compaction to finish.
     Set<CompactableFile> expectedFiles = new HashSet<>();
     params.getRunningCompactions().stream().filter(job -> job.getKind() == params.getKind())
@@ -323,8 +322,8 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     }
 
     var builder = params.createPlanBuilder();
-    compactionJobs.forEach(jobFiles -> builder.addJob(createPriority(params, jobFiles),
-        getGroup(jobFiles), jobFiles));
+    compactionJobs.forEach(
+        jobFiles -> builder.addJob(createPriority(params, jobFiles), getGroup(jobFiles), jobFiles));
     return builder.build();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -57,66 +57,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * compaction service you are configuring.
  *
  * <ul>
- * <li>{@code compaction.service.<service>.opts.executors} This is a json array of objects where
- * each object has the fields:
- * <table>
- * <caption>Default Compaction Planner Executor options</caption>
- * <tr>
- * <th>Field Name</th>
- * <th>Description</th>
- * </tr>
- * <tr>
- * <td>name</td>
- * <td>name or alias of the executor (required)</td>
- * </tr>
- * <tr>
- * <td>type</td>
- * <td>valid values 'internal' or 'external' (required)</td>
- * </tr>
- * <tr>
- * <td>maxSize</td>
- * <td>threshold sum of the input files (required for all but one of the configs)</td>
- * </tr>
- * <tr>
- * <td>numThreads</td>
- * <td>number of threads for this executor configuration (required for 'internal', cannot be
- * specified for 'external')</td>
- * </tr>
- * <tr>
- * <td>group</td>
- * <td>name of the external compaction group (required for 'external', cannot be specified for
- * 'internal')</td>
- * </tr>
- * </table>
- * <br>
- * Note: The "executors" option has been deprecated in 3.1 and will be removed in a future release.
- * This example uses the new `compaction.service` prefix. The property prefix
- * "tserver.compaction.major.service" has also been deprecated in 3.1 and will be removed in a
- * future release. The maxSize field determines the maximum size of compaction that will run on an
- * executor. The maxSize field can have a suffix of K,M,G for kilobytes, megabytes, or gigabytes and
- * represents the sum of the input files for a given compaction. One executor can have no max size
- * and it will run everything that is too large for the other executors. If all executors have a max
- * size, then system compactions will only run for compactions smaller than the largest max size.
- * User, chop, and selector compactions will always run, even if there is no executor for their
- * size. These compactions will run on the executor with the largest max size. The following example
- * value for this property will create 3 threads to run compactions of files whose file size sum is
- * less than 100M, 3 threads to run compactions of files whose file size sum is less than 500M, and
- * run all other compactions on Compactors configured to run compactions for Queue1:
- *
- * <pre>
- * {@code
- * [
- *  {"name":"small", "type": "internal", "maxSize":"100M","numThreads":3},
- *  {"name":"medium", "type": "internal", "maxSize":"500M","numThreads":3},
- *  {"name": "large", "type": "external", "group", "Queue1"}
- * ]}
- * </pre>
- *
- * Note that the use of 'external' requires that the CompactionCoordinator and at least one
- * Compactor for Queue1 is running.
+ * Note that the CompactionCoordinator and at least one Compactor for "Large" must be running.
  * <li>{@code compaction.service.<service>.opts.maxOpen} This determines the maximum number of files
  * that will be included in a single compaction.
- * <li>{@code compaction.service.<service>.opts.queues} This is a json array of queue objects which
+ * <li>{@code compaction.service.<service>.opts.groups} This is a json array of group objects which
  * have the following fields:
  * <table>
  * <caption>Default Compaction Planner Queue options</caption>
@@ -126,7 +70,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * </tr>
  * <tr>
  * <td>name</td>
- * <td>name or alias of the queue (required)</td>
+ * <td>name or alias of the group (required)</td>
  * </tr>
  * <tr>
  * <td>maxSize</td>
@@ -134,8 +78,28 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * </tr>
  * </table>
  * <br>
- * This 'queues' object is used for defining external compaction queues without needing to use the
- * thread-based 'executors' property.
+ * This 'groups' object is used for defining compaction groups.
+ *
+ * The maxSize field determines the maximum size of compaction that will run in a
+ * group. The maxSize field can have a suffix of K,M,G for kilobytes, megabytes, or gigabytes and
+ * represents the sum of the input files for a given compaction. One group can have no max size
+ * and it will run everything that is too large for the other groups. If all groups have a max
+ * size, then system compactions will only run for compactions smaller than the largest max size.
+ * User, chop, and selector compactions will always run, even if there is no group for their
+ * size. These compactions will run on the group with the largest max size. The following example
+ * value for this property will create three separate compaction groups. "small" will run compactions of files whose file size sum is
+ * less than 100M, "medium" will run compactions of files whose file size sum is less than 500M, and "large" will run
+ * all other compactions on Compactors configured to run compactions for Large:
+ *
+ * <pre>
+ * {@code
+ * [
+ *  {"name":"small", "maxSize":"100M"},
+ *  {"name":"medium", "maxSize":"500M"},
+ *  {"name": "large"}
+ * ]}
+ * </pre>
+ *
  * </ul>
  *
  * @since 3.1.0
@@ -146,67 +110,18 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
 
   private final static Logger log = LoggerFactory.getLogger(DefaultCompactionPlanner.class);
 
-  private static class ExecutorConfig {
-    String type;
-    String name;
-    String maxSize;
-    Integer numThreads;
-    String group;
-
-    public String getType() {
-      return type;
-    }
-
-    public void setType(String type) {
-      this.type = type;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public void setName(String name) {
-      this.name = name;
-    }
-
-    public String getMaxSize() {
-      return maxSize;
-    }
-
-    public void setMaxSize(String maxSize) {
-      this.maxSize = maxSize;
-    }
-
-    public Integer getNumThreads() {
-      return numThreads;
-    }
-
-    public void setNumThreads(Integer numThreads) {
-      this.numThreads = numThreads;
-    }
-
-    public String getQueue() {
-      return group;
-    }
-
-    public void setGroup(String group) {
-      this.group = group;
-    }
-
-  }
-
-  private static class QueueConfig {
+  private static class GroupConfig {
     String name;
     String maxSize;
   }
 
-  private static class Executor {
-    final CompactionExecutorId ceid;
+  private static class CompactionGroup {
+    final CompactionGroupId cgid;
     final Long maxSize;
 
-    public Executor(CompactionExecutorId ceid, Long maxSize) {
+    public CompactionGroup(CompactionGroupId cgid, Long maxSize) {
       Preconditions.checkArgument(maxSize == null || maxSize > 0, "Invalid value for maxSize");
-      this.ceid = Objects.requireNonNull(ceid, "Compaction ID is null");
+      this.cgid = Objects.requireNonNull(cgid, "Compaction ID is null");
       this.maxSize = maxSize;
     }
 
@@ -216,7 +131,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
 
     @Override
     public String toString() {
-      return "[ceid=" + ceid + ", maxSize=" + maxSize + "]";
+      return "[cgid=" + cgid + ", maxSize=" + maxSize + "]";
     }
   }
 
@@ -236,100 +151,57 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     }
   }
 
-  private List<Executor> executors;
+  private List<CompactionGroup> groups;
   private int maxFilesToCompact;
 
   @SuppressFBWarnings(value = {"UWF_UNWRITTEN_FIELD", "NP_UNWRITTEN_FIELD"},
       justification = "Field is written by Gson")
   @Override
   public void init(InitParameters params) {
-    List<Executor> tmpExec = new ArrayList<>();
+    List<CompactionGroup> tmpGroups = new ArrayList<>();
     String values;
 
-    if (params.getOptions().containsKey("executors")
-        && !params.getOptions().get("executors").isBlank()) {
-      values = params.getOptions().get("executors");
+    if (params.getOptions().containsKey("groups") && !params.getOptions().get("groups").isBlank()) {
+      values = params.getOptions().get("groups");
 
       // Generate a list of fields from the desired object.
-      final List<String> execFields = Arrays.stream(ExecutorConfig.class.getDeclaredFields())
+      final List<String> groupFields = Arrays.stream(GroupConfig.class.getDeclaredFields())
           .map(Field::getName).collect(Collectors.toList());
 
       for (JsonElement element : GSON.get().fromJson(values, JsonArray.class)) {
-        validateConfig(element, execFields, ExecutorConfig.class.getName());
-        ExecutorConfig executorConfig = GSON.get().fromJson(element, ExecutorConfig.class);
+        validateConfig(element, groupFields, GroupConfig.class.getName());
+        GroupConfig groupConfig = GSON.get().fromJson(element, GroupConfig.class);
 
-        Long maxSize = executorConfig.maxSize == null ? null
-            : ConfigurationTypeHelper.getFixedMemoryAsBytes(executorConfig.maxSize);
-        CompactionExecutorId ceid;
+        Long maxSize = groupConfig.maxSize == null ? null
+            : ConfigurationTypeHelper.getFixedMemoryAsBytes(groupConfig.maxSize);
 
-        // If not supplied, GSON will leave type null. Default to internal
-        if (executorConfig.type == null) {
-          executorConfig.type = "internal";
-        }
-
-        switch (executorConfig.type) {
-          case "internal":
-            Preconditions.checkArgument(null == executorConfig.group,
-                "'group' should not be specified for internal compactions");
-            int numThreads = Objects.requireNonNull(executorConfig.numThreads,
-                "'numThreads' must be specified for internal type");
-            ceid = params.getExecutorManager().createExecutor(executorConfig.name, numThreads);
-            break;
-          case "external":
-            Preconditions.checkArgument(null == executorConfig.numThreads,
-                "'numThreads' should not be specified for external compactions");
-            String group = Objects.requireNonNull(executorConfig.group,
-                "'group' must be specified for external type");
-            ceid = params.getExecutorManager().getExternalExecutor(group);
-            break;
-          default:
-            throw new IllegalArgumentException("type must be 'internal' or 'external'");
-        }
-        tmpExec.add(new Executor(ceid, maxSize));
+        CompactionGroupId cgid;
+        String group = Objects.requireNonNull(groupConfig.name, "'name' must be specified");
+        cgid = params.getGroupManager().getGroup(group);
+        tmpGroups.add(new CompactionGroup(cgid, maxSize));
       }
     }
 
-    if (params.getOptions().containsKey("queues") && !params.getOptions().get("queues").isBlank()) {
-      values = params.getOptions().get("queues");
-
-      // Generate a list of fields from the desired object.
-      final List<String> queueFields = Arrays.stream(QueueConfig.class.getDeclaredFields())
-          .map(Field::getName).collect(Collectors.toList());
-
-      for (JsonElement element : GSON.get().fromJson(values, JsonArray.class)) {
-        validateConfig(element, queueFields, QueueConfig.class.getName());
-        QueueConfig queueConfig = GSON.get().fromJson(element, QueueConfig.class);
-
-        Long maxSize = queueConfig.maxSize == null ? null
-            : ConfigurationTypeHelper.getFixedMemoryAsBytes(queueConfig.maxSize);
-
-        CompactionExecutorId ceid;
-        String queue = Objects.requireNonNull(queueConfig.name, "'name' must be specified");
-        ceid = params.getExecutorManager().getExternalExecutor(queue);
-        tmpExec.add(new Executor(ceid, maxSize));
-      }
+    if (tmpGroups.size() < 1) {
+      throw new IllegalStateException("No defined compaction groups for this planner");
     }
 
-    if (tmpExec.size() < 1) {
-      throw new IllegalStateException("No defined executors or queues for this planner");
-    }
-
-    tmpExec.sort(Comparator.comparing(Executor::getMaxSize,
+    tmpGroups.sort(Comparator.comparing(CompactionGroup::getMaxSize,
         Comparator.nullsLast(Comparator.naturalOrder())));
 
-    executors = List.copyOf(tmpExec);
+    groups = List.copyOf(tmpGroups);
 
-    if (executors.stream().filter(e -> e.getMaxSize() == null).count() > 1) {
+    if (groups.stream().filter(g -> g.getMaxSize() == null).count() > 1) {
       throw new IllegalArgumentException(
-          "Can only have one executor w/o a maxSize. " + params.getOptions().get("executors"));
+          "Can only have one group w/o a maxSize. " + params.getOptions().get("groups"));
     }
 
     // use the add method on the Set interface to check for duplicate maxSizes
     Set<Long> maxSizes = new HashSet<>();
-    executors.forEach(e -> {
-      if (!maxSizes.add(e.getMaxSize())) {
+    groups.forEach(g -> {
+      if (!maxSizes.add(g.getMaxSize())) {
         throw new IllegalArgumentException(
-            "Duplicate maxSize set in executors. " + params.getOptions().get("executors"));
+            "Duplicate maxSize set in groups. " + params.getOptions().get("groups"));
       }
     });
 
@@ -373,7 +245,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     long maxSizeToCompact = getMaxSizeToCompact(params.getKind());
 
     // This set represents future files that will be produced by running compactions. If the optimal
-    // set of files to compact is computed and contains one of these files, then its optimal to wait
+    // set of files to compact is computed and contains one of these files, then it's optimal to wait
     // for this compaction to finish.
     Set<CompactableFile> expectedFiles = new HashSet<>();
     params.getRunningCompactions().stream().filter(job -> job.getKind() == params.getKind())
@@ -452,7 +324,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
 
     var builder = params.createPlanBuilder();
     compactionJobs.forEach(jobFiles -> builder.addJob(createPriority(params, jobFiles),
-        getExecutor(jobFiles), jobFiles));
+        getGroup(jobFiles), jobFiles));
     return builder.build();
   }
 
@@ -464,7 +336,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
 
   private long getMaxSizeToCompact(CompactionKind kind) {
     if (kind == CompactionKind.SYSTEM) {
-      Long max = executors.get(executors.size() - 1).maxSize;
+      Long max = groups.get(groups.size() - 1).maxSize;
       if (max != null) {
         return max;
       }
@@ -624,17 +496,17 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     return sortedFiles.subList(0, larsmaIndex + 1);
   }
 
-  CompactionExecutorId getExecutor(Collection<CompactableFile> files) {
+  CompactionGroupId getGroup(Collection<CompactableFile> files) {
 
     long size = files.stream().mapToLong(CompactableFile::getEstimatedSize).sum();
 
-    for (Executor executor : executors) {
-      if (executor.maxSize == null || size < executor.maxSize) {
-        return executor.ceid;
+    for (CompactionGroup group : groups) {
+      if (group.maxSize == null || size < group.maxSize) {
+        return group.cgid;
       }
     }
 
-    return executors.get(executors.size() - 1).ceid;
+    return groups.get(groups.size() - 1).cgid;
   }
 
   private static List<CompactableFile> sortByFileSize(Collection<CompactableFile> files) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/GroupManager.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/GroupManager.java
@@ -18,20 +18,16 @@
  */
 package org.apache.accumulo.core.spi.compaction;
 
-import org.apache.accumulo.core.data.AbstractId;
-
 /**
- * A unique identifier for a a compaction executor that a {@link CompactionPlanner} can schedule
- * compactions on using a {@link CompactionJob}.
+ * Offered to a Compaction Planner at initialization time, so it can create compaction groups.
  *
- * @since 2.1.0
+ * @since 3.1.0
+ * @see CompactionPlanner#init(org.apache.accumulo.core.spi.compaction.CompactionPlanner.InitParameters)
  * @see org.apache.accumulo.core.spi.compaction
  */
-public class CompactionExecutorId extends AbstractId<CompactionExecutorId> {
-  // ELASTICITY_TODO make this cache ids like TableId. This will help save manager memory.
-  private static final long serialVersionUID = 1L;
-
-  protected CompactionExecutorId(String canonical) {
-    super(canonical);
-  }
+public interface GroupManager {
+  /**
+   * @return an id for a configured compaction group.
+   */
+  CompactionGroupId getGroup(String name);
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionGroupIdImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionGroupIdImpl.java
@@ -18,34 +18,17 @@
  */
 package org.apache.accumulo.core.util.compaction;
 
-import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
-import org.apache.accumulo.core.spi.compaction.CompactionServiceId;
+import org.apache.accumulo.core.spi.compaction.CompactionGroupId;
 
-import com.google.common.base.Preconditions;
+public class CompactionGroupIdImpl extends CompactionGroupId {
 
-public class CompactionExecutorIdImpl extends CompactionExecutorId {
-
-  protected CompactionExecutorIdImpl(String canonical) {
+  protected CompactionGroupIdImpl(String canonical) {
     super(canonical);
   }
 
   private static final long serialVersionUID = 1L;
 
-  public boolean isExternalId() {
-    return canonical().startsWith("e.");
+  public static CompactionGroupId groupId(String groupName) {
+    return new CompactionGroupIdImpl(groupName);
   }
-
-  public String getExternalName() {
-    Preconditions.checkState(isExternalId());
-    return canonical().substring("e.".length());
-  }
-
-  public static CompactionExecutorId internalId(CompactionServiceId csid, String executorName) {
-    return new CompactionExecutorIdImpl("i." + csid + "." + executorName);
-  }
-
-  public static CompactionExecutorId externalId(String executorName) {
-    return new CompactionExecutorIdImpl("e." + executorName);
-  }
-
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobImpl.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
-import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
+import org.apache.accumulo.core.spi.compaction.CompactionGroupId;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 
@@ -37,10 +37,10 @@ import org.apache.accumulo.core.spi.compaction.CompactionKind;
 public class CompactionJobImpl implements CompactionJob {
 
   private final short priority;
-  private final CompactionExecutorId executor;
+  private final CompactionGroupId group;
   private final Set<CompactableFile> files;
   private final CompactionKind kind;
-  // Tracks if a job selected all of the tablets files that existed at the time the job was created.
+  // Tracks if a job selected all the tablet's files that existed at the time the job was created.
   private final Optional<Boolean> jobSelectedAll;
 
   /**
@@ -49,10 +49,10 @@ public class CompactionJobImpl implements CompactionJob {
    *        to start compaction. After a job is running, its not used. So when a job object is
    *        recreated for a running external compaction this parameter can be empty.
    */
-  public CompactionJobImpl(short priority, CompactionExecutorId executor,
+  public CompactionJobImpl(short priority, CompactionGroupId group,
       Collection<CompactableFile> files, CompactionKind kind, Optional<Boolean> jobSelectedAll) {
     this.priority = priority;
-    this.executor = Objects.requireNonNull(executor);
+    this.group = Objects.requireNonNull(group);
     this.files = Set.copyOf(files);
     this.kind = Objects.requireNonNull(kind);
     this.jobSelectedAll = Objects.requireNonNull(jobSelectedAll);
@@ -64,11 +64,11 @@ public class CompactionJobImpl implements CompactionJob {
   }
 
   /**
-   * @return The executor to run the job.
+   * @return The group to run the job.
    */
   @Override
-  public CompactionExecutorId getExecutor() {
-    return executor;
+  public CompactionGroupId getGroup() {
+    return group;
   }
 
   /**
@@ -89,7 +89,7 @@ public class CompactionJobImpl implements CompactionJob {
 
   @Override
   public int hashCode() {
-    return Objects.hash(priority, executor, files, kind);
+    return Objects.hash(priority, group, files, kind);
   }
 
   public boolean selectedAll() {
@@ -101,7 +101,7 @@ public class CompactionJobImpl implements CompactionJob {
     if (o instanceof CompactionJobImpl) {
       CompactionJobImpl ocj = (CompactionJobImpl) o;
 
-      return priority == ocj.priority && executor.equals(ocj.executor) && files.equals(ocj.files)
+      return priority == ocj.priority && group.equals(ocj.group) && files.equals(ocj.files)
           && kind == ocj.kind;
     }
 
@@ -110,7 +110,7 @@ public class CompactionJobImpl implements CompactionJob {
 
   @Override
   public String toString() {
-    return "CompactionJob [priority=" + priority + ", executor=" + executor + ", files=" + files
+    return "CompactionJob [priority=" + priority + ", group=" + group + ", files=" + files
         + ", kind=" + kind + "]";
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlanImpl.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
-import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
+import org.apache.accumulo.core.spi.compaction.CompactionGroupId;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.spi.compaction.CompactionPlan;
@@ -68,7 +68,7 @@ public class CompactionPlanImpl implements CompactionPlan {
     }
 
     @Override
-    public Builder addJob(short priority, CompactionExecutorId executor,
+    public Builder addJob(short priority, CompactionGroupId group,
         Collection<CompactableFile> files) {
       Set<CompactableFile> filesSet =
           files instanceof Set ? (Set<CompactableFile>) files : Set.copyOf(files);
@@ -80,7 +80,7 @@ public class CompactionPlanImpl implements CompactionPlan {
 
       seenFiles.addAll(filesSet);
 
-      jobs.add(new CompactionJobImpl(priority, executor, filesSet, kind,
+      jobs.add(new CompactionJobImpl(priority, group, filesSet, kind,
           Optional.of(filesSet.equals(allFiles))));
       return this;
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfig.java
@@ -22,34 +22,26 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
 /**
  * This class serves to configure compaction services from an {@link AccumuloConfiguration} object.
- *
- * Specifically, compaction service properties (those prefixed by "tserver.compaction.major
- * .service" or "compaction.service") are used.
+ * Specifically, compaction service properties (those prefixed by "compaction.service") are used.
  */
 public class CompactionServicesConfig {
 
-  private static final Logger log = LoggerFactory.getLogger(CompactionServicesConfig.class);
   private final Map<String,String> planners = new HashMap<>();
   private final Map<String,String> plannerPrefixes = new HashMap<>();
   private final Map<String,Long> rateLimits = new HashMap<>();
   private final Map<String,Map<String,String>> options = new HashMap<>();
 
-  @SuppressWarnings("deprecation")
-  private static final Property oldPrefix = Property.TSERV_COMPACTION_SERVICE_PREFIX;
-  private static final Property newPrefix = Property.COMPACTION_SERVICE_PREFIX;
+  private static final Property prefix = Property.COMPACTION_SERVICE_PREFIX;
 
   private interface ConfigIndirection {
     Map<String,String> getAllPropertiesWithPrefixStripped(Property p);
@@ -58,27 +50,8 @@ public class CompactionServicesConfig {
   private static Map<String,Map<String,String>> getConfiguration(ConfigIndirection aconf) {
     Map<String,Map<String,String>> properties = new HashMap<>();
 
-    var newProps = aconf.getAllPropertiesWithPrefixStripped(newPrefix);
-    properties.put(newPrefix.getKey(), newProps);
-
-    // get all the services under the new prefix
-    var newServices =
-        newProps.keySet().stream().map(prop -> prop.split("\\.")[0]).collect(Collectors.toSet());
-
-    Map<String,String> oldServices = new HashMap<>();
-
-    for (Map.Entry<String,String> entry : aconf.getAllPropertiesWithPrefixStripped(oldPrefix)
-        .entrySet()) {
-      // Discard duplicate service definitions
-      var service = entry.getKey().split("\\.")[0];
-      if (newServices.contains(service)) {
-        log.warn("Duplicate compaction service '{}' definition exists. Ignoring property : '{}'",
-            service, entry.getKey());
-      } else {
-        oldServices.put(entry.getKey(), entry.getValue());
-      }
-    }
-    properties.put(oldPrefix.getKey(), oldServices);
+    var newProps = aconf.getAllPropertiesWithPrefixStripped(prefix);
+    properties.put(prefix.getKey(), newProps);
     // Return unmodifiable map
     return Map.copyOf(properties);
   }
@@ -97,54 +70,21 @@ public class CompactionServicesConfig {
     this(getConfiguration(aconf::getAllPropertiesWithPrefixStripped), aconf::isPropertySet);
   }
 
-  @SuppressWarnings("removal")
   private CompactionServicesConfig(Map<String,Map<String,String>> configs,
       Predicate<Property> isSetPredicate) {
     configs.forEach((prefix, props) -> {
       props.forEach((prop, val) -> {
         String[] tokens = prop.split("\\.");
         if (tokens.length == 2 && tokens[1].equals("planner")) {
-          if (prefix.equals(oldPrefix.getKey())) {
-            // Log a warning if the old prefix planner is defined by a user.
-            Property userDefined = null;
-            try {
-              userDefined = Property.valueOf(prefix + prop);
-            } catch (IllegalArgumentException e) {
-              log.trace("Property: {} is not set by default configuration", prefix + prop);
-            }
-            boolean isPropSet = true;
-            if (userDefined != null) {
-              isPropSet = isSetPredicate.test(userDefined);
-            }
-            if (isPropSet) {
-              log.warn(
-                  "Found compaction planner '{}' using a deprecated prefix. Please update property to use the '{}' prefix",
-                  tokens[0], newPrefix);
-            }
-          }
           plannerPrefixes.put(tokens[0], prefix);
           planners.put(tokens[0], val);
-        }
-      });
-    });
-
-    // Now find all compaction planner options.
-    configs.forEach((prefix, props) -> {
-      props.forEach((prop, val) -> {
-        String[] tokens = prop.split("\\.");
-        if (!plannerPrefixes.containsKey(tokens[0])) {
-          throw new IllegalArgumentException(
-              "Incomplete compaction service definition, missing planner class: " + prop);
-        }
-        if (tokens.length == 4 && tokens[1].equals("planner") && tokens[2].equals("opts")) {
+        } else if (tokens.length == 4 && tokens[1].equals("planner") && tokens[2].equals("opts")) {
           options.computeIfAbsent(tokens[0], k -> new HashMap<>()).put(tokens[3], val);
         } else if (tokens.length == 3 && tokens[1].equals("rate") && tokens[2].equals("limit")) {
           var eprop = Property.getPropertyByKey(prop);
           if (eprop == null || isSetPredicate.test(eprop)) {
             rateLimits.put(tokens[0], ConfigurationTypeHelper.getFixedMemoryAsBytes(val));
           }
-        } else if (tokens.length == 2 && tokens[1].equals("planner")) {
-          return; // moves to next opt
         } else {
           throw new IllegalArgumentException(
               "Malformed compaction service property " + prefix + prop);

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -74,7 +74,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
-import org.apache.accumulo.core.util.compaction.CompactionExecutorIdImpl;
+import org.apache.accumulo.core.util.compaction.CompactionGroupIdImpl;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
@@ -384,8 +384,8 @@ public class TabletMetadataTest {
     assertThrows(IllegalStateException.class, tm2::getCompacted);
 
     var ecid1 = ExternalCompactionId.generate(UUID.randomUUID());
-    ExternalCompactionMetadata ecm = new ExternalCompactionMetadata(Set.of(sf1, sf2), rf1, "cid1",
-        CompactionKind.USER, (short) 3, CompactionExecutorIdImpl.externalId("Q1"), true, 99L);
+    CompactionMetadata ecm = new CompactionMetadata(Set.of(sf1, sf2), rf1, "cid1",
+        CompactionKind.USER, (short) 3, CompactionGroupIdImpl.groupId("Q1"), true, 99L);
 
     LogEntry le1 = new LogEntry("localhost:8020/" + UUID.randomUUID());
     LogEntry le2 = new LogEntry("localhost:8020/" + UUID.randomUUID());

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
@@ -44,7 +44,7 @@ public class CompactionPrioritizerTest {
     // TODO pass numFiles
     return new CompactionJobImpl(
         CompactionJobPrioritizer.createPriority(kind, totalFiles, numFiles),
-        CompactionExecutorIdImpl.externalId("test"), files, kind, Optional.of(false));
+        CompactionGroupIdImpl.groupId("test"), files, kind, Optional.of(false));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionServicesConfigTest.java
@@ -19,8 +19,6 @@
 package org.apache.accumulo.core.util.compaction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
@@ -31,58 +29,23 @@ import org.junit.jupiter.api.Test;
 
 public class CompactionServicesConfigTest {
 
-  @SuppressWarnings("deprecation")
-  private final Property oldPrefix = Property.TSERV_COMPACTION_SERVICE_PREFIX;
-  private final Property newPrefix = Property.COMPACTION_SERVICE_PREFIX;
+  private final Property prefix = Property.COMPACTION_SERVICE_PREFIX;
 
   @Test
   public void testCompactionProps() {
     ConfigurationCopy conf = new ConfigurationCopy();
 
-    conf.set(newPrefix.getKey() + "default.planner", DefaultCompactionPlanner.class.getName());
-    conf.set(newPrefix.getKey() + "default.planner.opts.maxOpen", "10");
-    conf.set(newPrefix.getKey() + "default.planner.opts.executors",
-        "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]");
+    conf.set(prefix.getKey() + "default.planner", DefaultCompactionPlanner.class.getName());
+    conf.set(prefix.getKey() + "default.planner.opts.maxOpen", "10");
+    conf.set(prefix.getKey() + "default.planner.opts.groups",
+        "[{'name':'small','maxSize':'32M'},{'name':'medium','maxSize':'128M'},{'name':'large'}]");
 
-    conf.set(oldPrefix.getKey() + "default.planner.opts.ignoredProp", "1");
-    conf.set(newPrefix.getKey() + "default.planner.opts.validProp", "1");
-    conf.set(oldPrefix.getKey() + "default.planner.opts.validProp", "a");
+    conf.set(prefix.getKey() + "default.planner.opts.validProp", "1");
 
     var compactionConfig = new CompactionServicesConfig(conf);
-    assertEquals(Map.of("maxOpen", "10", "executors",
-        "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]",
+    assertEquals(Map.of("maxOpen", "10", "groups",
+        "[{'name':'small','maxSize':'32M'},{'name':'medium','maxSize':'128M'},{'name':'large'}]",
         "validProp", "1"), compactionConfig.getOptions().get("default"));
-  }
-
-  @Test
-  public void testDuplicateCompactionPlannerDefs() {
-    ConfigurationCopy conf = new ConfigurationCopy();
-
-    String planner = DefaultCompactionPlanner.class.getName();
-    String oldPlanner = "OldPlanner";
-
-    conf.set(newPrefix.getKey() + "default.planner", planner);
-    conf.set(oldPrefix.getKey() + "default.planner", oldPlanner);
-
-    conf.set(oldPrefix.getKey() + "old.planner", oldPlanner);
-
-    var compactionConfig = new CompactionServicesConfig(conf);
-    assertEquals(Map.of("default", planner, "old", oldPlanner), compactionConfig.getPlanners());
-  }
-
-  @Test
-  public void testCompactionPlannerOldDef() {
-    ConfigurationCopy conf = new ConfigurationCopy();
-
-    conf.set(oldPrefix.getKey() + "cs1.planner", DefaultCompactionPlanner.class.getName());
-    conf.set(oldPrefix.getKey() + "cs1.planner.opts.maxOpen", "10");
-    conf.set(oldPrefix.getKey() + "cs1.planner.opts.executors",
-        "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]");
-    conf.set(oldPrefix.getKey() + "cs1.planner.opts.foo", "1");
-
-    var compactionConfig = new CompactionServicesConfig(conf);
-    assertTrue(compactionConfig.getOptions().get("cs1").containsKey("foo"));
-    assertEquals("1", compactionConfig.getOptions().get("cs1").get("foo"));
   }
 
   @Test
@@ -90,16 +53,9 @@ public class CompactionServicesConfigTest {
     ConfigurationCopy conf = new ConfigurationCopy();
     CompactionServicesConfig compactionConfig;
 
-    conf.set(oldPrefix.getKey() + "cs1.planner", DefaultCompactionPlanner.class.getName());
-    conf.set(oldPrefix.getKey() + "cs1.rate.limit", "2M");
+    conf.set(prefix.getKey() + "cs1.planner", DefaultCompactionPlanner.class.getName());
+    conf.set(prefix.getKey() + "cs1.rate.limit", "2M");
     compactionConfig = new CompactionServicesConfig(conf);
     assertEquals(2097152, compactionConfig.getRateLimits().get("cs1"));
-
-    // Test service collision
-    conf.set(newPrefix.getKey() + "cs1.rate.limit", "4M");
-    var e = assertThrows(IllegalArgumentException.class, () -> new CompactionServicesConfig(conf),
-        "failed to throw error");
-    assertEquals("Incomplete compaction service definition, missing planner class: cs1.rate.limit",
-        e.getMessage(), "Error message was not equal");
   }
 }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -704,16 +704,9 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
         var initParams = new CompactionPlannerInitParams(CompactionServiceId.of(serviceId),
             csc.getPlannerPrefix(serviceId), csc.getOptions().get(serviceId), senv);
         cp.init(initParams);
-        initParams.getRequestedExternalExecutors().forEach(ceid -> {
-          String id = ceid.canonical();
-          if (id.startsWith("e.")) {
-            groupNames.add(id.substring(2));
-          } else {
-            groupNames.add(id);
-          }
-        });
+        initParams.getRequestedGroups().forEach(gid -> groupNames.add(gid.canonical()));
       } catch (Exception e) {
-        log.error("For compaction service {}, failed to get compaction queues from planner {}.",
+        log.error("For compaction service {}, failed to get compaction groups from planner {}.",
             serviceId, plannerClass, e);
       }
     }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -166,21 +166,21 @@ public class MiniAccumuloConfigImpl {
 
       mergeProp(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE.getKey(),
           Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE.getDefaultValue());
-      mergeProp(Property.TSERV_COMPACTION_SERVICE_ROOT_PLANNER.getKey(),
-          Property.TSERV_COMPACTION_SERVICE_ROOT_PLANNER.getDefaultValue());
-      mergeProp(Property.TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS.getKey(),
-          Property.TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS.getDefaultValue());
+      mergeProp(Property.COMPACTION_SERVICE_ROOT_PLANNER.getKey(),
+          Property.COMPACTION_SERVICE_ROOT_PLANNER.getDefaultValue());
+      mergeProp(Property.COMPACTION_SERVICE_ROOT_GROUPS.getKey(),
+          Property.COMPACTION_SERVICE_ROOT_GROUPS.getDefaultValue());
 
-      mergeProp(Property.TSERV_COMPACTION_SERVICE_META_PLANNER.getKey(),
-          Property.TSERV_COMPACTION_SERVICE_META_PLANNER.getDefaultValue());
-      mergeProp(Property.TSERV_COMPACTION_SERVICE_META_EXECUTORS.getKey(),
-          Property.TSERV_COMPACTION_SERVICE_META_EXECUTORS.getDefaultValue());
+      mergeProp(Property.COMPACTION_SERVICE_META_PLANNER.getKey(),
+          Property.COMPACTION_SERVICE_META_PLANNER.getDefaultValue());
+      mergeProp(Property.COMPACTION_SERVICE_META_GROUPS.getKey(),
+          Property.COMPACTION_SERVICE_META_GROUPS.getDefaultValue());
 
-      mergeProp(Property.TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER.getKey(),
-          Property.TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER.getDefaultValue());
+      mergeProp(Property.COMPACTION_SERVICE_DEFAULT_PLANNER.getKey(),
+          Property.COMPACTION_SERVICE_DEFAULT_PLANNER.getDefaultValue());
 
-      mergeProp(Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
-          Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS.getDefaultValue());
+      mergeProp(Property.COMPACTION_SERVICE_DEFAULT_GROUPS.getKey(),
+          Property.COMPACTION_SERVICE_DEFAULT_GROUPS.getDefaultValue());
 
       if (isUseCredentialProvider()) {
         updateConfigForCredentialProvider();

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionJobGenerator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionJobGenerator.java
@@ -266,7 +266,7 @@ public class CompactionJobGenerator {
           Collection<CompactableFile> files = ecMeta.getJobFiles().stream()
               .map(f -> new CompactableFileImpl(f, allFiles2.get(f))).collect(Collectors.toList());
           CompactionJob job = new CompactionJobImpl(ecMeta.getPriority(),
-              ecMeta.getCompactionExecutorId(), files, ecMeta.getKind(), Optional.empty());
+              ecMeta.getCompactionGroupId(), files, ecMeta.getKind(), Optional.empty());
           return job;
         }).collect(Collectors.toUnmodifiableList());
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/CheckCompactionConfig.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/CheckCompactionConfig.java
@@ -117,16 +117,9 @@ public class CheckCompactionConfig implements KeywordExecutable {
 
       planner.init(initParams);
 
-      initParams.getRequestedExecutors()
-          .forEach((execId, numThreads) -> log.info(
-              "Compaction service '{}' requested creation of thread pool '{}' with {} threads.",
-              serviceId, execId, numThreads));
-
-      initParams.getRequestedExternalExecutors()
-          .forEach(execId -> log.info(
-              "Compaction service '{}' requested with external execution group '{}'", serviceId,
-              execId));
-
+      initParams.getRequestedGroups().forEach(
+          (groupId -> log.info("Compaction service '{}' requested with compaction group '{}'",
+              serviceId, groupId)));
     }
 
     log.info("Properties file has passed all checks.");

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.JsonParseException;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path not set by user input")
@@ -49,10 +51,9 @@ public class CheckCompactionConfigTest extends WithTestNames {
   public void testValidInput1() throws Exception {
     String inputString = ("compaction.service.cs1.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':4},\\\n"
-        + "{'name':'large','type':'internal','numThreads':2}]").replaceAll("'", "\"");
+        + "compaction.service.cs1.planner.opts.groups=\\\n"
+        + "[{'name':'small','maxSize':'16M'},{'name':'medium','maxSize':'128M'},\\\n"
+        + "{'name':'large'}]").replaceAll("'", "\"");
 
     String filePath = writeToFileAndReturnPath(inputString);
 
@@ -63,16 +64,13 @@ public class CheckCompactionConfigTest extends WithTestNames {
   public void testValidInput2() throws Exception {
     String inputString = ("compaction.service.cs1.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':4},\\\n"
-        + "{'name':'large','type':'internal','numThreads':2}] \n"
-        + "compaction.service.cs2.planner="
+        + "compaction.service.cs1.planner.opts.groups=\\\n"
+        + "[{'name':'small','maxSize':'16M'},{'name':'medium','maxSize':'128M'},\\\n"
+        + "{'name':'large'}] \ncompaction.service.cs2.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs2.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':7},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':5},\\\n"
-        + "{'name':'large','type':'external','group':'DCQ1'}]").replaceAll("'", "\"");
+        + "compaction.service.cs2.planner.opts.groups=\\\n"
+        + "[{'name':'small','maxSize':'16M'},{'name':'medium','maxSize':'128M'},\\\n"
+        + "{'name':'large'}]").replaceAll("'", "\"");
 
     String filePath = writeToFileAndReturnPath(inputString);
 
@@ -83,19 +81,15 @@ public class CheckCompactionConfigTest extends WithTestNames {
   public void testValidInput3() throws Exception {
     String inputString = ("compaction.service.cs1.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':4},\\\n"
-        + "{'name':'large','type':'internal','numThreads':2}] \n"
-        + "compaction.service.cs2.planner="
+        + "compaction.service.cs1.planner.opts.groups=\\\n"
+        + "[{'name':'small','maxSize':'16M'},{'name':'medium','maxSize':'128M'},\\\n"
+        + "{'name':'large'}] \ncompaction.service.cs2.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs2.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':7},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':5},\\\n"
-        + "{'name':'large','type':'external','group':'DCQ1'}] \n"
-        + "compaction.service.cs3.planner="
+        + "compaction.service.cs2.planner.opts.groups=\\\n"
+        + "[{'name':'small','maxSize':'16M'}, {'name':'medium','maxSize':'128M'},\\\n"
+        + "{'name':'large'}] \ncompaction.service.cs3.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs3.planner.opts.queues=\\\n"
+        + "compaction.service.cs3.planner.opts.groups=\\\n"
         + "[{'name':'small','maxSize':'16M'},{'name':'large'}]").replaceAll("'", "\"");
 
     String filePath = writeToFileAndReturnPath(inputString);
@@ -103,46 +97,29 @@ public class CheckCompactionConfigTest extends WithTestNames {
   }
 
   @Test
-  public void testThrowsExternalNumThreadsError() throws IOException {
+  public void testThrowsInvalidFieldsError() throws IOException {
     String inputString = ("compaction.service.cs1.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
-        + "{'name':'medium','type':'external','maxSize':'128M', 'group':'DCQ1', 'numThreads':4},\\\n"
-        + "{'name':'large','type':'internal','numThreads':2}]").replaceAll("'", "\"");
-    String expectedErrorMsg = "'numThreads' should not be specified for external compactions";
+        + "compaction.service.cs1.planner.opts.groups=\\\n"
+        + "[{'name':'small','maxSize':'16M'},{'name':'medium','maxSize':'128M'},\\\n"
+        + "{'name':'large','numThreads':2}]").replaceAll("'", "\"");
+    String expectedErrorMsg =
+        "Invalid fields: [numThreads] provided for class: org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner$GroupConfig";
 
     String filePath = writeToFileAndReturnPath(inputString);
 
-    var e = assertThrows(IllegalArgumentException.class,
+    var e = assertThrows(JsonParseException.class,
         () -> CheckCompactionConfig.main(new String[] {filePath}));
     assertEquals(expectedErrorMsg, e.getMessage());
   }
 
   @Test
-  public void testNegativeThreadCount() throws IOException {
-    String inputString = ("compaction.service.cs1.planner="
-        + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':-4},\\\n"
-        + "{'name':'large','type':'internal','numThreads':2}]").replaceAll("'", "\"");
-    String expectedErrorMsg = "Positive number of threads required : -4";
-
-    String filePath = writeToFileAndReturnPath(inputString);
-
-    var e = assertThrows(IllegalArgumentException.class,
-        () -> CheckCompactionConfig.main(new String[] {filePath}));
-    assertEquals(e.getMessage(), expectedErrorMsg);
-  }
-
-  @Test
   public void testNoPlanner() throws Exception {
-    String inputString = ("compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':4},\\\n"
-        + "{'name':'large','type':'internal','numThreads':2}]").replaceAll("'", "\"");
-    String expectedErrorMsg = "Incomplete compaction service definition, missing planner class";
+    String inputString = ("compaction.service.cs1.planner.opts.groups=\\\n"
+        + "[{'name':'small','maxSize':'16M'}, {'name':'medium','maxSize':'128M'},\\\n"
+        + "{'name':'large'}]").replaceAll("'", "\"");
+    String expectedErrorMsg =
+        "Incomplete compaction service definitions, missing planner class [cs1]";
 
     String filePath = writeToFileAndReturnPath(inputString);
 
@@ -152,51 +129,15 @@ public class CheckCompactionConfigTest extends WithTestNames {
   }
 
   @Test
-  public void testRepeatedCompactionExecutorID() throws Exception {
+  public void testRepeatedCompactionGroup() throws Exception {
     String inputString = ("compaction.service.cs1.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':4},\\\n"
-        + "{'name':'small','type':'internal','numThreads':2}]").replaceAll("'", "\"");
-    String expectedErrorMsg = "Duplicate Compaction Executor ID found";
+        + "compaction.service.cs1.planner.opts.groups=\\\n"
+        + "[{'name':'small','maxSize':'16M'},{'name':'medium','maxSize':'128M'},\\\n"
+        + "{'name':'small'}]").replaceAll("'", "\"");
+    String expectedErrorMsg = "Duplicate compaction group for group: small";
 
     final String filePath = writeToFileAndReturnPath(inputString);
-
-    var e = assertThrows(IllegalStateException.class,
-        () -> CheckCompactionConfig.main(new String[] {filePath}));
-    assertTrue(e.getMessage().startsWith(expectedErrorMsg));
-  }
-
-  @Test
-  public void testRepeatedQueueName() throws Exception {
-    String inputString = ("compaction.service.cs1.planner="
-        + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'external','maxSize':'16M','group':'failedQueue'}] \n"
-        + "compaction.service.cs1.planner.opts.queues=[{'name':'failedQueue'}]")
-        .replaceAll("'", "\"");
-
-    String expectedErrorMsg = "Duplicate external executor for group failedQueue";
-
-    final String filePath = writeToFileAndReturnPath(inputString);
-
-    var err = assertThrows(IllegalArgumentException.class,
-        () -> CheckCompactionConfig.main(new String[] {filePath}));
-    assertEquals(err.getMessage(), expectedErrorMsg);
-  }
-
-  @Test
-  public void testInvalidTypeValue() throws Exception {
-    String inputString = ("compaction.service.cs1.planner="
-        + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'128M','numThreads':4},\\\n"
-        + "{'name':'large','type':'internl','numThreads':2}]").replaceAll("'", "\"");
-    String expectedErrorMsg = "type must be 'internal' or 'external'";
-
-    String filePath = writeToFileAndReturnPath(inputString);
 
     var e = assertThrows(IllegalArgumentException.class,
         () -> CheckCompactionConfig.main(new String[] {filePath}));
@@ -207,10 +148,9 @@ public class CheckCompactionConfigTest extends WithTestNames {
   public void testInvalidMaxSize() throws Exception {
     String inputString = ("compaction.service.cs1.planner="
         + "org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner \n"
-        + "compaction.service.cs1.planner.opts.executors=\\\n"
-        + "[{'name':'small','type':'internal','maxSize':'16M','numThreads':8},\\\n"
-        + "{'name':'medium','type':'internal','maxSize':'0M','numThreads':4},\\\n"
-        + "{'name':'large','type':'internal','numThreads':2}]").replaceAll("'", "\"");
+        + "compaction.service.cs1.planner.opts.groups=\\\n"
+        + "[{'name':'small','maxSize':'16M'},{'name':'medium','maxSize':'0M'},\\\n"
+        + "{'name':'large'}]").replaceAll("'", "\"");
     String expectedErrorMsg = "Invalid value for maxSize";
 
     String filePath = writeToFileAndReturnPath(inputString);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/coordinator/CompactionCoordinator.java
@@ -86,9 +86,9 @@ import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.Refreshes.RefreshEntry;
 import org.apache.accumulo.core.metadata.schema.Ample.RejectionHandler;
+import org.apache.accumulo.core.metadata.schema.CompactionMetadata;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
-import org.apache.accumulo.core.metadata.schema.ExternalCompactionMetadata;
 import org.apache.accumulo.core.metadata.schema.SelectedFiles;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
@@ -105,7 +105,7 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletServerClientService;
 import org.apache.accumulo.core.util.Retry;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.core.util.cache.Caches.CacheName;
-import org.apache.accumulo.core.util.compaction.CompactionExecutorIdImpl;
+import org.apache.accumulo.core.util.compaction.CompactionGroupIdImpl;
 import org.apache.accumulo.core.util.compaction.ExternalCompactionUtil;
 import org.apache.accumulo.core.util.compaction.RunningCompaction;
 import org.apache.accumulo.core.util.threads.ThreadPools;
@@ -395,8 +395,7 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
 
     TExternalCompactionJob result = null;
 
-    CompactionJobQueues.MetaJob metaJob =
-        jobQueues.poll(CompactionExecutorIdImpl.externalId(groupName));
+    CompactionJobQueues.MetaJob metaJob = jobQueues.poll(CompactionGroupIdImpl.groupId(groupName));
 
     while (metaJob != null) {
 
@@ -404,7 +403,7 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
 
       // this method may reread the metadata, do not use the metadata in metaJob for anything after
       // this method
-      ExternalCompactionMetadata ecm = null;
+      CompactionMetadata ecm = null;
 
       var kind = metaJob.getJob().getKind();
 
@@ -428,7 +427,7 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
       } else {
         LOG.debug("Unable to reserve compaction job for {}, pulling another off the queue ",
             metaJob.getTabletMetadata().getExtent());
-        metaJob = jobQueues.poll(CompactionExecutorIdImpl.externalId(groupName));
+        metaJob = jobQueues.poll(CompactionGroupIdImpl.groupId(groupName));
       }
     }
 
@@ -513,7 +512,7 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
     }
   }
 
-  private ExternalCompactionMetadata createExternalCompactionMetadata(CompactionJob job,
+  private CompactionMetadata createExternalCompactionMetadata(CompactionJob job,
       Set<StoredTabletFile> jobFiles, TabletMetadata tablet, String compactorAddress,
       ExternalCompactionId externalCompactionId) {
     boolean propDels;
@@ -542,12 +541,12 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
     ReferencedTabletFile newFile = TabletNameGenerator.getNextDataFilenameForMajc(propDels, ctx,
         tablet, directoryCreator, externalCompactionId);
 
-    return new ExternalCompactionMetadata(jobFiles, newFile, compactorAddress, job.getKind(),
-        job.getPriority(), job.getExecutor(), propDels, fateTxId);
+    return new CompactionMetadata(jobFiles, newFile, compactorAddress, job.getKind(),
+        job.getPriority(), job.getGroup(), propDels, fateTxId);
 
   }
 
-  private ExternalCompactionMetadata reserveCompaction(CompactionJobQueues.MetaJob metaJob,
+  private CompactionMetadata reserveCompaction(CompactionJobQueues.MetaJob metaJob,
       String compactorAddress, ExternalCompactionId externalCompactionId) {
 
     Preconditions.checkArgument(metaJob.getJob().getKind() == CompactionKind.SYSTEM
@@ -602,9 +601,8 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
     return null;
   }
 
-  TExternalCompactionJob createThriftJob(String externalCompactionId,
-      ExternalCompactionMetadata ecm, CompactionJobQueues.MetaJob metaJob,
-      Optional<CompactionConfig> compactionConfig) {
+  TExternalCompactionJob createThriftJob(String externalCompactionId, CompactionMetadata ecm,
+      CompactionJobQueues.MetaJob metaJob, Optional<CompactionConfig> compactionConfig) {
 
     Map<String,String> overrides = CompactionPluginUtils.computeOverrides(compactionConfig, ctx,
         metaJob.getTabletMetadata().getExtent(), metaJob.getJob().getFiles());
@@ -767,7 +765,7 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
       return;
     }
 
-    ExternalCompactionMetadata ecm = tabletMeta.getExternalCompactions().get(ecid);
+    CompactionMetadata ecm = tabletMeta.getExternalCompactions().get(ecid);
 
     // ELASTICITY_TODO this code does not handle race conditions or faults. Need to ensure refresh
     // happens in the case of manager process death between commit and refresh.
@@ -810,7 +808,7 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
   }
 
   private Optional<ReferencedTabletFile> renameOrDeleteFile(TCompactionStats stats,
-      ExternalCompactionMetadata ecm, ReferencedTabletFile newDatafile) throws IOException {
+      CompactionMetadata ecm, ReferencedTabletFile newDatafile) throws IOException {
     if (stats.getEntriesWritten() == 0) {
       // the compaction produced no output so do not need to rename or add a file to the metadata
       // table, only delete the input files.
@@ -864,7 +862,7 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
       return false;
     }
 
-    ExternalCompactionMetadata ecm = tabletMetadata.getExternalCompactions().get(ecid);
+    CompactionMetadata ecm = tabletMetadata.getExternalCompactions().get(ecid);
 
     if (ecm == null) {
       LOG.debug("Received completion notification for unknown compaction {} {}", ecid, extent);
@@ -919,7 +917,7 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
         .logInterval(3, MINUTES).createRetry();
 
     while (canCommitCompaction(ecid, tablet)) {
-      ExternalCompactionMetadata ecm = tablet.getExternalCompactions().get(ecid);
+      CompactionMetadata ecm = tablet.getExternalCompactions().get(ecid);
 
       // the compacted files should not exists in the tablet already
       var tablet2 = tablet;
@@ -984,7 +982,7 @@ public class CompactionCoordinator implements CompactionCoordinatorService.Iface
 
   private void updateTabletForCompaction(TCompactionStats stats, ExternalCompactionId ecid,
       TabletMetadata tablet, Optional<ReferencedTabletFile> newDatafile, KeyExtent extent,
-      ExternalCompactionMetadata ecm, Ample.ConditionalTabletMutator tabletMutator) {
+      CompactionMetadata ecm, Ample.ConditionalTabletMutator tabletMutator) {
     // ELASTICITY_TODO improve logging adapt to use existing tablet files logging
     if (ecm.getKind() == CompactionKind.USER) {
       if (tablet.getSelectedFiles().getFiles().equals(ecm.getJobFiles())) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobPriorityQueue.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
+import org.apache.accumulo.core.spi.compaction.CompactionGroupId;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.util.compaction.CompactionJobPrioritizer;
 
@@ -48,7 +48,7 @@ import com.google.common.base.Preconditions;
  */
 public class CompactionJobPriorityQueue {
   // ELASTICITY_TODO unit test this class
-  private final CompactionExecutorId executorId;
+  private final CompactionGroupId groupId;
 
   private class CjpqKey implements Comparable<CjpqKey> {
     private final CompactionJob job;
@@ -106,11 +106,11 @@ public class CompactionJobPriorityQueue {
 
   private boolean closed = false;
 
-  public CompactionJobPriorityQueue(CompactionExecutorId executorId, int maxSize) {
+  public CompactionJobPriorityQueue(CompactionGroupId groupId, int maxSize) {
     this.jobQueue = new TreeMap<>();
     this.maxSize = maxSize;
     this.tabletJobs = new HashMap<>();
-    this.executorId = executorId;
+    this.groupId = groupId;
     this.rejectedJobs = new AtomicLong(0);
     this.dequeuedJobs = new AtomicLong(0);
   }
@@ -120,8 +120,7 @@ public class CompactionJobPriorityQueue {
       return false;
     }
 
-    Preconditions
-        .checkArgument(jobs.stream().allMatch(job -> job.getExecutor().equals(executorId)));
+    Preconditions.checkArgument(jobs.stream().allMatch(job -> job.getGroup().equals(groupId)));
 
     removePreviousSubmissions(tabletMetadata.getExtent());
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/compaction/queue/CompactionJobQueues.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap.KeySetView;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
+import org.apache.accumulo.core.spi.compaction.CompactionGroupId;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +39,7 @@ public class CompactionJobQueues {
   // can be observed that scoped locks are acquired. Other concurrent map impls may run the compute
   // lambdas concurrently for a given key, which may still be correct but is more difficult to
   // analyze.
-  private final ConcurrentHashMap<CompactionExecutorId,CompactionJobPriorityQueue> priorityQueues =
+  private final ConcurrentHashMap<CompactionGroupId,CompactionJobPriorityQueue> priorityQueues =
       new ConcurrentHashMap<>();
 
   private final int queueSize;
@@ -50,44 +50,44 @@ public class CompactionJobQueues {
 
   public void add(TabletMetadata tabletMetadata, Collection<CompactionJob> jobs) {
     if (jobs.size() == 1) {
-      var executorId = jobs.iterator().next().getExecutor();
+      var executorId = jobs.iterator().next().getGroup();
       add(tabletMetadata, executorId, jobs);
     } else {
-      jobs.stream().collect(Collectors.groupingBy(CompactionJob::getExecutor)).forEach(
-          ((executorId, compactionJobs) -> add(tabletMetadata, executorId, compactionJobs)));
+      jobs.stream().collect(Collectors.groupingBy(CompactionJob::getGroup))
+          .forEach(((groupId, compactionJobs) -> add(tabletMetadata, groupId, compactionJobs)));
     }
   }
 
-  public KeySetView<CompactionExecutorId,CompactionJobPriorityQueue> getQueueIds() {
+  public KeySetView<CompactionGroupId,CompactionJobPriorityQueue> getQueueIds() {
     return priorityQueues.keySet();
   }
 
-  public CompactionJobPriorityQueue getQueue(CompactionExecutorId executorId) {
-    return priorityQueues.get(executorId);
+  public CompactionJobPriorityQueue getQueue(CompactionGroupId groupId) {
+    return priorityQueues.get(groupId);
   }
 
-  public long getQueueMaxSize(CompactionExecutorId executorId) {
-    var prioQ = priorityQueues.get(executorId);
+  public long getQueueMaxSize(CompactionGroupId groupId) {
+    var prioQ = priorityQueues.get(groupId);
     return prioQ == null ? 0 : prioQ.getMaxSize();
   }
 
-  public long getQueuedJobs(CompactionExecutorId executorId) {
-    var prioQ = priorityQueues.get(executorId);
+  public long getQueuedJobs(CompactionGroupId groupId) {
+    var prioQ = priorityQueues.get(groupId);
     return prioQ == null ? 0 : prioQ.getQueuedJobs();
   }
 
-  public long getDequeuedJobs(CompactionExecutorId executorId) {
-    var prioQ = priorityQueues.get(executorId);
+  public long getDequeuedJobs(CompactionGroupId groupId) {
+    var prioQ = priorityQueues.get(groupId);
     return prioQ == null ? 0 : prioQ.getDequeuedJobs();
   }
 
-  public long getRejectedJobs(CompactionExecutorId executorId) {
-    var prioQ = priorityQueues.get(executorId);
+  public long getRejectedJobs(CompactionGroupId groupId) {
+    var prioQ = priorityQueues.get(groupId);
     return prioQ == null ? 0 : prioQ.getRejectedJobs();
   }
 
-  public long getLowestPriority(CompactionExecutorId executorId) {
-    var prioQ = priorityQueues.get(executorId);
+  public long getLowestPriority(CompactionGroupId groupId) {
+    var prioQ = priorityQueues.get(groupId);
     return prioQ == null ? 0 : prioQ.getLowestPriority();
   }
 
@@ -123,15 +123,15 @@ public class CompactionJobQueues {
     }
   }
 
-  public MetaJob poll(CompactionExecutorId executorId) {
-    var prioQ = priorityQueues.get(executorId);
+  public MetaJob poll(CompactionGroupId groupId) {
+    var prioQ = priorityQueues.get(groupId);
     if (prioQ == null) {
       return null;
     }
     MetaJob mj = prioQ.poll();
 
     if (mj == null) {
-      priorityQueues.computeIfPresent(executorId, (eid, pq) -> {
+      priorityQueues.computeIfPresent(groupId, (eid, pq) -> {
         if (pq.closeIfEmpty()) {
           return null;
         } else {
@@ -142,23 +142,23 @@ public class CompactionJobQueues {
     return mj;
   }
 
-  private void add(TabletMetadata tabletMetadata, CompactionExecutorId executorId,
+  private void add(TabletMetadata tabletMetadata, CompactionGroupId groupId,
       Collection<CompactionJob> jobs) {
 
     // TODO log level
     if (log.isDebugEnabled()) {
-      log.debug("Adding jobs to queue {} {} {}", executorId, tabletMetadata.getExtent(),
+      log.debug("Adding jobs to queue {} {} {}", groupId, tabletMetadata.getExtent(),
           jobs.stream().map(job -> "#files:" + job.getFiles().size() + ",prio:" + job.getPriority()
               + ",kind:" + job.getKind()).collect(Collectors.toList()));
     }
 
-    var pq = priorityQueues.computeIfAbsent(executorId,
-        eid -> new CompactionJobPriorityQueue(eid, queueSize));
+    var pq = priorityQueues.computeIfAbsent(groupId,
+        gid -> new CompactionJobPriorityQueue(gid, queueSize));
     while (!pq.add(tabletMetadata, jobs)) {
       // This loop handles race condition where poll() closes empty priority queues. The queue could
       // be closed after its obtained from the map and before add is called.
-      pq = priorityQueues.computeIfAbsent(executorId,
-          eid -> new CompactionJobPriorityQueue(eid, queueSize));
+      pq = priorityQueues.computeIfAbsent(groupId,
+          gid -> new CompactionJobPriorityQueue(gid, queueSize));
     }
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/QueueMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/QueueMetrics.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.metrics.MetricsProducer;
-import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
+import org.apache.accumulo.core.spi.compaction.CompactionGroupId;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.manager.compaction.queue.CompactionJobPriorityQueue;
 import org.apache.accumulo.manager.compaction.queue.CompactionJobQueues;
@@ -50,7 +50,7 @@ public class QueueMetrics implements MetricsProducer {
     private final Gauge jobsRejected;
     private final Gauge jobsLowestPriority;
 
-    public QueueMeters(MeterRegistry meterRegistry, CompactionExecutorId queueId,
+    public QueueMeters(MeterRegistry meterRegistry, CompactionGroupId queueId,
         CompactionJobPriorityQueue queue) {
       length =
           Gauge.builder(METRICS_COMPACTOR_JOB_PRIORITY_QUEUE_LENGTH, queue, q -> q.getMaxSize())
@@ -99,7 +99,7 @@ public class QueueMetrics implements MetricsProducer {
   private static final long DEFAULT_MIN_REFRESH_DELAY = TimeUnit.SECONDS.toMillis(5);
   private MeterRegistry meterRegistry = null;
   private final CompactionJobQueues compactionJobQueues;
-  private final Map<CompactionExecutorId,QueueMeters> perQueueMetrics = new HashMap<>();
+  private final Map<CompactionGroupId,QueueMeters> perQueueMetrics = new HashMap<>();
   private Gauge queueCountMeter = null;
 
   public QueueMetrics(CompactionJobQueues compactionJobQueues) {
@@ -121,20 +121,20 @@ public class QueueMetrics implements MetricsProducer {
     }
     LOG.debug("update - cjq queues: {}", compactionJobQueues.getQueueIds());
 
-    Set<CompactionExecutorId> definedQueues = compactionJobQueues.getQueueIds();
+    Set<CompactionGroupId> definedQueues = compactionJobQueues.getQueueIds();
     LOG.debug("update - defined queues: {}", definedQueues);
 
-    Set<CompactionExecutorId> queuesWithMetrics = perQueueMetrics.keySet();
+    Set<CompactionGroupId> queuesWithMetrics = perQueueMetrics.keySet();
     LOG.debug("update - queues with metrics: {}", queuesWithMetrics);
 
-    SetView<CompactionExecutorId> queuesWithoutMetrics =
+    SetView<CompactionGroupId> queuesWithoutMetrics =
         Sets.difference(definedQueues, queuesWithMetrics);
     queuesWithoutMetrics.forEach(q -> {
       LOG.debug("update - creating meters for queue: {}", q);
       perQueueMetrics.put(q, new QueueMeters(meterRegistry, q, compactionJobQueues.getQueue(q)));
     });
 
-    SetView<CompactionExecutorId> metricsWithoutQueues =
+    SetView<CompactionGroupId> metricsWithoutQueues =
         Sets.difference(queuesWithMetrics, definedQueues);
     metricsWithoutQueues.forEach(q -> {
       LOG.debug("update - removing meters for queue: {}", q);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionPriorityQueueMetricsIT.java
@@ -155,9 +155,8 @@ public class CompactionPriorityQueueMetricsIT extends SharedMiniClusterBase {
       // Create a new queue with zero compactors.
       cfg.setProperty("tserver.compaction.major.service." + QUEUE1_SERVICE + ".planner",
           DefaultCompactionPlanner.class.getName());
-      cfg.setProperty(
-          "tserver.compaction.major.service." + QUEUE1_SERVICE + ".planner.opts.executors",
-          "[{'name':'all', 'type': 'external', 'group': '" + QUEUE1 + "'}]");
+      cfg.setProperty("tserver.compaction.major.service." + QUEUE1_SERVICE + ".planner.opts.groups",
+          "[{'name':'" + QUEUE1 + "'}]");
 
       cfg.setProperty(Property.MANAGER_COMPACTION_SERVICE_PRIORITY_QUEUE_SIZE, "6");
       cfg.getClusterServerConfiguration().addCompactorResourceGroup(QUEUE1, 0);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
@@ -197,36 +197,36 @@ public class ExternalCompactionTestUtils {
     // configure the compaction services to use the queues
     cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner",
         DefaultCompactionPlanner.class.getName());
-    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner.opts.executors",
-        "[{'name':'all', 'type': 'external', 'group': '" + GROUP1 + "'}]");
+    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs1.planner.opts.groups",
+        "[{'name':'" + GROUP1 + "'}]");
     cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs2.planner",
         DefaultCompactionPlanner.class.getName());
-    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs2.planner.opts.executors",
-        "[{'name':'all', 'type': 'external','group': '" + GROUP2 + "'}]");
+    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs2.planner.opts.groups",
+        "[{'name':'" + GROUP2 + "'}]");
     cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs3.planner",
         DefaultCompactionPlanner.class.getName());
-    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs3.planner.opts.executors",
-        "[{'name':'all', 'type': 'external','group': '" + GROUP3 + "'}]");
+    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs3.planner.opts.groups",
+        "[{'name':'" + GROUP3 + "'}]");
     cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs4.planner",
         DefaultCompactionPlanner.class.getName());
-    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs4.planner.opts.executors",
-        "[{'name':'all', 'type': 'external','group': '" + GROUP4 + "'}]");
+    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs4.planner.opts.groups",
+        "[{'name':'" + GROUP4 + "'}]");
     cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs5.planner",
         DefaultCompactionPlanner.class.getName());
-    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs5.planner.opts.executors",
-        "[{'name':'all', 'type': 'external','group': '" + GROUP5 + "'}]");
+    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs5.planner.opts.groups",
+        "[{'name':'" + GROUP5 + "'}]");
     cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs6.planner",
         DefaultCompactionPlanner.class.getName());
-    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs6.planner.opts.executors",
-        "[{'name':'all', 'type': 'external','group': '" + GROUP6 + "'}]");
+    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs6.planner.opts.groups",
+        "[{'name':'" + GROUP6 + "'}]");
     cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs7.planner",
         DefaultCompactionPlanner.class.getName());
-    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs7.planner.opts.executors",
-        "[{'name':'all', 'type': 'external','group': '" + GROUP7 + "'}]");
+    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs7.planner.opts.groups",
+        "[{'name':'" + GROUP7 + "'}]");
     cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs8.planner",
         DefaultCompactionPlanner.class.getName());
-    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs8.planner.opts.executors",
-        "[{'name':'all', 'type': 'external','group': '" + GROUP8 + "'}]");
+    cfg.setProperty(Property.COMPACTION_SERVICE_PREFIX.getKey() + "cs8.planner.opts.groups",
+        "[{'name':'" + GROUP8 + "'}]");
     cfg.setProperty(Property.COMPACTION_COORDINATOR_FINALIZER_COMPLETION_CHECK_INTERVAL, "5s");
     cfg.setProperty(Property.COMPACTION_COORDINATOR_DEAD_COMPACTOR_CHECK_INTERVAL, "5s");
     cfg.setProperty(Property.COMPACTION_COORDINATOR_TSERVER_COMPACTION_CHECK_INTERVAL, "3s");

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -280,7 +280,6 @@ public class FateIT {
       Wait.waitFor(() -> IN_PROGRESS == getTxStatus(zk, txid));
       // This is false because the transaction runner has reserved the FaTe
       // transaction.
-      Wait.waitFor(() -> IN_PROGRESS == getTxStatus(zk, txid));
       assertFalse(fate.cancel(txid));
       callStarted.await();
       finishCall.countDown();

--- a/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ConfigSetIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.shell;
 
+import static org.apache.accumulo.core.conf.Property.COMPACTION_SERVICE_ROOT_GROUPS;
 import static org.apache.accumulo.core.conf.Property.MONITOR_RESOURCES_EXTERNAL;
-import static org.apache.accumulo.core.conf.Property.TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -53,17 +53,14 @@ public class ConfigSetIT extends SharedMiniClusterBase {
   public void setInvalidJson() throws Exception {
     log.debug("Starting setInvalidJson test ------------------");
 
-    String validJson =
-        "[{'name':'small','type':'internal','maxSize':'64M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
-            .replaceAll("'", "\"");
+    String validJson = "[{'name':'small','maxSize':'64M'},{'name':'huge'}]".replaceAll("'", "\"");
 
     // missing first value
     String invalidJson = "notJson";
 
     try (AccumuloClient client =
         getCluster().createAccumuloClient("root", new PasswordToken(getRootPassword()))) {
-      client.instanceOperations().setProperty(TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS.getKey(),
-          validJson);
+      client.instanceOperations().setProperty(COMPACTION_SERVICE_ROOT_GROUPS.getKey(), validJson);
       assertThrows(AccumuloException.class, () -> client.instanceOperations()
           .setProperty(MONITOR_RESOURCES_EXTERNAL.getKey(), invalidJson));
 


### PR DESCRIPTION
This PR removes the deprecated `executors` property and replaces it with `groups`. 
This also remove many references to "External" compactions but does not yet modify any "external" naming that may be tied to persisted data. 

Once this PR is merged, any specific changes in `main` will be addressed to allow for a clean deprecation path. 

Thoughts: 

The concept of a Compaction Group has been introduced in main via #4020, but doesn't currently mesh well with the internal and external compaction types still co-existing. 

For deprecation patterns, the `COMPACTION_SERVICE_<service>_QUEUES` property is going to be switched in `main` to `COMPACTION_SERVICE_<service>_GROUPS`.

We may need to add some specific validation around the group name, (allowed characters, length, etc).